### PR TITLE
Change functionality to use classes instead of constructors

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,16 +111,17 @@ libraryEle.addEventListener("click", (e) => {
         let index;
         
         let book;
-        for (let i = 0; i < Library.library.length; i++) {
-            if (Library.library[i].id === id) {
-                book = Library.library[i];
+        let lib = Library.getLibrary();
+        for (let i = 0; i < lib.length; i++) {
+            if (lib[i].id === id) {
+                book = lib[i];
                 index = i;
                 break;
             }
         }
         
         if (e.target.classList.contains("delete-button")) {
-            Library.library.splice(index, 1);
+            lib.splice(index, 1);
             libraryEle.removeChild(bookEle);
         } else { // read-button
             book.updateReadStatus();

--- a/index.js
+++ b/index.js
@@ -1,44 +1,53 @@
 // Book storage and functionality
 
 class Book {
-    title;
-    author;
-    pageNum;
-    hasBeenRead;
-    id;
+    #title;
+    #author;
+    #pageNum;
+    #hasBeenRead;
+    #id;
     constructor(title, author, pageNum, hasBeenRead) {
-        this.title = title;
-        this.author = author;
-        this.pageNum = pageNum;
-        this.hasBeenRead = hasBeenRead ? "Has been read" : "Hasn't been read";
-        this.id = crypto.randomUUID();
+        this.#title = title;
+        this.#author = author;
+        this.#pageNum = pageNum;
+        this.#hasBeenRead = hasBeenRead ? "Has been read" : "Hasn't been read";
+        this.#id = crypto.randomUUID();
     }
 
     get title() {
-        return this.title;
+        return this.#title;
     }
 
     get author() {
-        return this.author;
+        return this.#author;
     }
 
     get pageNum() {
-        return this.pageNum;
+        return this.#pageNum;
     }
 
     get hasBeenRead() {
-        return this.hasBeenRead;
+        return this.#hasBeenRead;
     }
 
     get id() {
-        return this.id;
+        return this.#id;
+    }
+
+    getFields() {
+        return {
+            title: this.title,
+            author: this.author,
+            pageNum: this.pageNum,
+            hasBeenRead: this.hasBeenRead,
+            id: this.id};
     }
 
     updateReadStatus() {
-        if (this.hasBeenRead.at(3)=== " ") { // Has been read
-        this.hasBeenRead = "Hasn't been read";
+        if (this.#hasBeenRead.at(3)=== " ") { // Has been read
+        this.#hasBeenRead = "Hasn't been read";
         } else { // Hasn't been read
-            this.hasBeenRead = "Has been read";
+            this.#hasBeenRead = "Has been read";
         }
     }
 }
@@ -84,10 +93,10 @@ function addBookToLibraryElement(book) {
     // Book itself
     const bookEle = document.createElement("div");
     bookEle.classList.add("book");
-    const entries = Object.keys(book); // keys is used so prototype functions aren't included when adding elements to bookEle
-    for (let k of entries) { // Array uses for/of
+    const entries = book.getFields();
+    for (let k in entries) {
         const ele = document.createElement("p");
-        ele.innerText += [k] + ": " + book[[k]];
+        ele.innerText += [k] + ": " + entries[k];
         bookEle.appendChild(ele);
     }
     bookEle.id = book.id;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 // Book storage and functionality
-// const library = [];
 
 class Book {
     title;
@@ -51,6 +50,13 @@ class Library {
         Library.#library.push(book);
     }
 
+    static removeBookFromLibrary(index) {
+        if (index >= Library.#library.length) {
+            return;
+        }
+        Library.#library.splice(index, 1);
+    }
+
     static createAndAddBookToLibrary(title, author, pageNum, hasBeenRead) {
         let id = crypto.randomUUID();
         const newBook = new Book(title, author, pageNum, hasBeenRead, id);
@@ -58,8 +64,8 @@ class Library {
         return newBook;
     }
 
-    static getLibrary() {
-        return Library.#library;
+    static getCopyOfLibrary() {
+        return [...Library.#library];
     }
 }
 
@@ -70,7 +76,7 @@ const book3 = Library.createAndAddBookToLibrary("Book 3", "Tony ony",   1, true)
 
 // DOM manipulation
 const libraryEle = document.querySelector(".library");
-for (let book of Library.getLibrary()) { // Array uses for/of (This is part of initial, I need the library element however)
+for (let book of Library.getCopyOfLibrary()) { // Array uses for/of (This is part of initial, I need the library element however)
     addBookToLibraryElement(book);
 }
 
@@ -111,7 +117,7 @@ libraryEle.addEventListener("click", (e) => {
         let index;
         
         let book;
-        let lib = Library.getLibrary();
+        let lib = Library.getCopyOfLibrary();
         for (let i = 0; i < lib.length; i++) {
             if (lib[i].id === id) {
                 book = lib[i];
@@ -121,7 +127,7 @@ libraryEle.addEventListener("click", (e) => {
         }
         
         if (e.target.classList.contains("delete-button")) {
-            lib.splice(index, 1);
+            Library.removeBookFromLibrary(index);
             libraryEle.removeChild(bookEle);
         } else { // read-button
             book.updateReadStatus();

--- a/index.js
+++ b/index.js
@@ -28,13 +28,9 @@ function addBookToLibrary(title, author, pageNum, hasBeenRead) {
 }
 
 // Initial books for display/testing purposes
-const book1 = new Book("Book 1", "Mary Sue", 100, true,  crypto.randomUUID());
-const book2 = new Book("Book 2", "John Doe", 111, false, crypto.randomUUID());
-const book3 = new Book("Book 3", "Anth ony",   1, true,  crypto.randomUUID());
-
-library.push(book1);
-library.push(book2);
-library.push(book3);
+const book1 = addBookToLibrary("Book 1", "Mary Sue", 100, true);
+const book2 = addBookToLibrary("Book 2", "John Doe", 111, false);
+const book3 = addBookToLibrary("Book 3", "Anth ony",   1, true);
 
 // DOM manipulation
 const libraryEle = document.querySelector(".library");

--- a/index.js
+++ b/index.js
@@ -2,37 +2,37 @@
 // const library = [];
 
 class Book {
-    #title;
-    #author;
-    #pageNum;
-    #hasBeenRead;
-    #id;
+    title;
+    author;
+    pageNum;
+    hasBeenRead;
+    id;
     constructor(title, author, pageNum, hasBeenRead) {
-        this.#title = title;
-        this.#author = author;
-        this.#pageNum = pageNum;
-        this.#hasBeenRead = hasBeenRead ? "Has been read" : "Hasn't been read";
-        this.#id = crypto.randomUUID();
+        this.title = title;
+        this.author = author;
+        this.pageNum = pageNum;
+        this.hasBeenRead = hasBeenRead ? "Has been read" : "Hasn't been read";
+        this.id = crypto.randomUUID();
     }
 
     get title() {
-        return this.#title;
+        return this.title;
     }
 
     get author() {
-        return this.#author;
+        return this.author;
     }
 
     get pageNum() {
-        return this.#pageNum;
+        return this.pageNum;
     }
 
     get hasBeenRead() {
-        return this.#hasBeenRead;
+        return this.hasBeenRead;
     }
 
     get id() {
-        return this.#id;
+        return this.id;
     }
 
     updateReadStatus() {
@@ -66,7 +66,7 @@ class Library {
 // Initial books for display/testing purposes
 const book1 = Library.createAndAddBookToLibrary("Book 1", "Mary Sue", 100, true);
 const book2 = Library.createAndAddBookToLibrary("Book 2", "John Doe", 111, false);
-const book3 = Library.createAndAddBookToLibrary("Book 3", "Anth ony",   1, true);
+const book3 = Library.createAndAddBookToLibrary("Book 3", "Tony ony",   1, true);
 
 // DOM manipulation
 const libraryEle = document.querySelector(".library");

--- a/index.js
+++ b/index.js
@@ -1,40 +1,76 @@
 // Book storage and functionality
-const library = [];
+// const library = [];
 
-function Book(title, author, pageNum, hasBeenRead, id) {
-    if (!new.target) {
-        throw Error("Book can only be called as a constructor");
+class Book {
+    #title;
+    #author;
+    #pageNum;
+    #hasBeenRead;
+    #id;
+    constructor(title, author, pageNum, hasBeenRead) {
+        this.#title = title;
+        this.#author = author;
+        this.#pageNum = pageNum;
+        this.#hasBeenRead = hasBeenRead ? "Has been read" : "Hasn't been read";
+        this.#id = crypto.randomUUID();
     }
-    this.title = title;
-    this.author = author;
-    this.pageNum = pageNum;
-    this.hasBeenRead = hasBeenRead ? "Has been read" : "Hasn't been read";
-    this.id = id;
-};
 
-Book.prototype.updateReadStatus = function() {
-    if (this.hasBeenRead.at(3)=== " ") { // Has been read
+    get title() {
+        return this.#title;
+    }
+
+    get author() {
+        return this.#author;
+    }
+
+    get pageNum() {
+        return this.#pageNum;
+    }
+
+    get hasBeenRead() {
+        return this.#hasBeenRead;
+    }
+
+    get id() {
+        return this.#id;
+    }
+
+    updateReadStatus() {
+        if (this.hasBeenRead.at(3)=== " ") { // Has been read
         this.hasBeenRead = "Hasn't been read";
-    } else { // Hasn't been read
-        this.hasBeenRead = "Has been read";
+        } else { // Hasn't been read
+            this.hasBeenRead = "Has been read";
+        }
     }
-};
+}
 
-function addBookToLibrary(title, author, pageNum, hasBeenRead) {
-    let id = crypto.randomUUID();
-    const newBook = new Book(title, author, pageNum, hasBeenRead, id);
-    library.push(newBook);
-    return newBook;
+class Library {
+    static #library = [];
+    
+    static addBookToLibrary(book) {
+        Library.#library.push(book);
+    }
+
+    static createAndAddBookToLibrary(title, author, pageNum, hasBeenRead) {
+        let id = crypto.randomUUID();
+        const newBook = new Book(title, author, pageNum, hasBeenRead, id);
+        Library.#library.push(newBook);
+        return newBook;
+    }
+
+    static getLibrary() {
+        return Library.#library;
+    }
 }
 
 // Initial books for display/testing purposes
-const book1 = addBookToLibrary("Book 1", "Mary Sue", 100, true);
-const book2 = addBookToLibrary("Book 2", "John Doe", 111, false);
-const book3 = addBookToLibrary("Book 3", "Anth ony",   1, true);
+const book1 = Library.createAndAddBookToLibrary("Book 1", "Mary Sue", 100, true);
+const book2 = Library.createAndAddBookToLibrary("Book 2", "John Doe", 111, false);
+const book3 = Library.createAndAddBookToLibrary("Book 3", "Anth ony",   1, true);
 
 // DOM manipulation
 const libraryEle = document.querySelector(".library");
-for (let book of library) { // Array uses for/of
+for (let book of Library.getLibrary()) { // Array uses for/of (This is part of initial, I need the library element however)
     addBookToLibraryElement(book);
 }
 
@@ -75,16 +111,16 @@ libraryEle.addEventListener("click", (e) => {
         let index;
         
         let book;
-        for (let i = 0; i < library.length; i++) {
-            if (library[i].id === id) {
-                book = library[i];
+        for (let i = 0; i < Library.library.length; i++) {
+            if (Library.library[i].id === id) {
+                book = Library.library[i];
                 index = i;
                 break;
             }
         }
         
         if (e.target.classList.contains("delete-button")) {
-            library.splice(index, 1);
+            Library.library.splice(index, 1);
             libraryEle.removeChild(bookEle);
         } else { // read-button
             book.updateReadStatus();
@@ -125,7 +161,7 @@ addBookButton.addEventListener("click", (e) => {
 
     if (author != "" && title != "" && pageNum > 0) { // If all required fields are filled
         e.preventDefault();
-        const newBook = addBookToLibrary(title, author, pageNum, hasBeenRead);
+        const newBook = Library.createAndAddBookToLibrary(title, author, pageNum, hasBeenRead);
         addBookToLibraryElement(newBook);
         // Clear info for next book
         clearDialogForm();


### PR DESCRIPTION
There is now a Book and Library class that handles the logic instead of just the constructors and a global library variable.

Book
- Private fields (getters for each)
- Constructor no longer takes an ID, instead it creates one when called
- getFields() returns an object containing the fields of a book
 - This is used when adding books to the page
- updateReadStatus() is now here

Library
- Holds the library variable, which is private and static
- static addBookToLibrary(book) and static removeBookFromLibrary(index) do as they say
 - remove uses index since that was the prior functionality, you could also use something like an ID but this works for now
- static createAndAddBookToLibrary() is basically a book constructor wrapped in a function for adding it to the library at the same time, but in the Library class
- static getCopyOfLibrary() is used to do things on a per book basis or to search through the library for a specific book

Other code logic changed to use these classes